### PR TITLE
Add LLM interaction helpers and live workflow example

### DIFF
--- a/examples/llm_end_to_end_demo.py
+++ b/examples/llm_end_to_end_demo.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from memoir_ai.core import MemoirAI
 from memoir_ai.query.query_strategy_engine import QueryStrategy
+from memoir_ai.text_processing.contextual_helper import ContextualHelperGenerator
 
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s %(levelname)s [%(name)s] %(message)s"
@@ -38,6 +39,19 @@ async def run_demo() -> None:
         chunk_max_tokens=220,
     )
 
+    contextual_helper = ContextualHelperGenerator()
+    user_provided_context = contextual_helper.create_user_provided_helper(
+        title="",
+        author="Jane Doe",
+        date="2023-10-05",
+        topic="Middle East Politics",
+        source_type="news_article",
+        description=(
+            "A news article discussing recent political events in the Middle East, "
+            "focusing on key figures and international reactions."
+        ),
+    )
+
     from sample_data_set.news_26_09_2025_0 import news_article
 
     sample_text = news_article
@@ -45,7 +59,7 @@ async def run_demo() -> None:
     ingestion_result = await memoir.ingest_text(
         content=sample_text.strip(),
         source_id="demo-doc",
-        contextual_helper="news article from 26th of September 2025",
+        contextual_helper=user_provided_context,
     )
 
     if not ingestion_result.success:

--- a/examples/llm_end_to_end_demo.py
+++ b/examples/llm_end_to_end_demo.py
@@ -1,0 +1,91 @@
+"""End-to-end example using real LLM calls via Pydantic AI."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+
+from memoir_ai.core import MemoirAI
+from memoir_ai.query.query_strategy_engine import QueryStrategy
+
+
+async def run_demo() -> None:
+    """Execute ingestion and querying with live LLM interactions."""
+
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        print(
+            "\n⚠️  Please set the OPENAI_API_KEY environment variable before running this demo.\n"
+        )
+        return
+
+    database_path = Path("./memoir_llm_demo.db")
+
+    if database_path.exists():
+        database_path.unlink()
+
+    memoir = MemoirAI(
+        database_url=f"sqlite:///{database_path}",
+        model_name="openai:gpt-4o-mini",
+        hierarchy_depth=3,
+        chunk_min_tokens=80,
+        chunk_max_tokens=220,
+    )
+
+    sample_text = """
+MemoirAI is an experimental knowledge management system. It focuses on
+creating rich hierarchical categories that capture the nuance of long-form
+content. The project combines automated text chunking with LLM powered
+classification to organize articles, research papers, meeting notes, and more.
+"""
+
+    print("\nIngesting sample document using live classification...\n")
+    ingestion_result = await memoir.ingest_text(
+        content=sample_text.strip(),
+        source_id="demo-doc",
+        contextual_helper="Internal README for the MemoirAI library",
+    )
+
+    if not ingestion_result.success:
+        print("Ingestion failed:", ingestion_result.error_message)
+        return
+
+    print(
+        f"Stored {ingestion_result.chunks_stored} chunks across "
+        f"{ingestion_result.categories_created} new categories."
+    )
+    for detail in ingestion_result.chunk_details:
+        print(
+            f"  - Chunk {detail['chunk_index']} classified into path "
+            f"{detail['category_path']} (latency: {detail['classification_latency_ms']} ms)"
+        )
+
+    print("\nRunning a query that triggers LLM category selection...\n")
+    query_result = await memoir.query_processor.process_query(
+        query_text="How does MemoirAI organize documents?",
+        strategy=QueryStrategy.ONE_SHOT,
+        contextual_helper="User wants a brief explanation of the system",
+        chunk_limit_per_path=5,
+    )
+
+    for response in query_result.responses:
+        llm_output = response.llm_output
+        if llm_output:
+            print(
+                f"LLM selected path with relevance {llm_output.ranked_relevance}: "
+                f"{response.llm_output.category}"
+            )
+
+    print(f"\nRetrieved {query_result.total_chunks} chunk(s) for inspection.\n")
+    for chunk in query_result.chunks:
+        preview = chunk.text_content[:120].replace("\n", " ")
+        print(f"Category Path: {chunk.category_path}")
+        print(f"Preview: {preview}...")
+        print("-")
+
+    memoir.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(run_demo())

--- a/examples/llm_end_to_end_demo.py
+++ b/examples/llm_end_to_end_demo.py
@@ -64,7 +64,7 @@ async def run_demo() -> None:
 
     print("\nRunning a query that triggers LLM category selection...\n")
     query_result = await memoir.query_processor.process_query(
-        query_text="How does MemoirAI organize documents?",
+        query_text="What happened with Netanyahu?",
         strategy=QueryStrategy.ONE_SHOT,
         contextual_helper="User wants a brief explanation of the system",
         chunk_limit_per_path=5,

--- a/examples/llm_end_to_end_demo.py
+++ b/examples/llm_end_to_end_demo.py
@@ -3,11 +3,16 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 from pathlib import Path
 
 from memoir_ai.core import MemoirAI
 from memoir_ai.query.query_strategy_engine import QueryStrategy
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s %(levelname)s [%(name)s] %(message)s"
+)
 
 
 async def run_demo() -> None:
@@ -33,18 +38,14 @@ async def run_demo() -> None:
         chunk_max_tokens=220,
     )
 
-    sample_text = """
-MemoirAI is an experimental knowledge management system. It focuses on
-creating rich hierarchical categories that capture the nuance of long-form
-content. The project combines automated text chunking with LLM powered
-classification to organize articles, research papers, meeting notes, and more.
-"""
+    from sample_data_set.news_26_09_2025_0 import news_article
 
+    sample_text = news_article
     print("\nIngesting sample document using live classification...\n")
     ingestion_result = await memoir.ingest_text(
         content=sample_text.strip(),
         source_id="demo-doc",
-        contextual_helper="Internal README for the MemoirAI library",
+        contextual_helper="news article from 26th of September 2025",
     )
 
     if not ingestion_result.success:

--- a/examples/sample_data_set/news_26_09_2025_0.py
+++ b/examples/sample_data_set/news_26_09_2025_0.py
@@ -7,6 +7,17 @@ Delegates staged a mass walkout as Israeli prime minister Benjamin Netanyahu gav
 There were boos as he decried the growing global recognition of a Palestinian state and vowed Israel would continue to fight in Gaza and “finish the job” of eliminating Hamas. The remarks fly in the face of international pressure on Netanyahu to end the war.
 
 Addressing rows of empty seats at the UN General Assembly on Friday, he firmly rejected giving the Palestinians a state, and told world leaders who have recognised such a state this week that “we will not allow you to shove a terror state down our throats”.
+"""
+
+news_article_b = """
+# UN delegates lead a mass walkout as Netanyahu insists Israel must ‘finish the job’ in Gaza
+Delegates stormed out during Benjamin Netanyahu’s speech as he lambasted nations for ‘caving’ to Hamas
+
+Delegates staged a mass walkout as Israeli prime minister Benjamin Netanyahu gave his UN address, shortly before he railed against nations that have “waged a political and legal war” against his country.
+
+There were boos as he decried the growing global recognition of a Palestinian state and vowed Israel would continue to fight in Gaza and “finish the job” of eliminating Hamas. The remarks fly in the face of international pressure on Netanyahu to end the war.
+
+Addressing rows of empty seats at the UN General Assembly on Friday, he firmly rejected giving the Palestinians a state, and told world leaders who have recognised such a state this week that “we will not allow you to shove a terror state down our throats”.
 
 Dozens of delegates walked out of the chamber as Netanyahu, who is wanted for war crimes by the International Criminal Court, took to the podium.
 

--- a/examples/sample_data_set/news_26_09_2025_0.py
+++ b/examples/sample_data_set/news_26_09_2025_0.py
@@ -1,0 +1,69 @@
+news_article = """
+# UN delegates lead a mass walkout as Netanyahu insists Israel must ‘finish the job’ in Gaza
+Delegates stormed out during Benjamin Netanyahu’s speech as he lambasted nations for ‘caving’ to Hamas
+
+Delegates staged a mass walkout as Israeli prime minister Benjamin Netanyahu gave his UN address, shortly before he railed against nations that have “waged a political and legal war” against his country.
+
+There were boos as he decried the growing global recognition of a Palestinian state and vowed Israel would continue to fight in Gaza and “finish the job” of eliminating Hamas. The remarks fly in the face of international pressure on Netanyahu to end the war.
+
+Addressing rows of empty seats at the UN General Assembly on Friday, he firmly rejected giving the Palestinians a state, and told world leaders who have recognised such a state this week that “we will not allow you to shove a terror state down our throats”.
+
+Dozens of delegates walked out of the chamber as Netanyahu, who is wanted for war crimes by the International Criminal Court, took to the podium.
+
+He accused world leaders of buckling “when the going got tough” for Israel.
+
+“When the going got tough, you caved,” he said to the mostly empty chamber.
+
+“And here is the shameless result of that collapse. For much of the past two years, Israel has had to fight a seven-front war against barbarism with many of your nations opposing us.
+
+Benjamin Netanyahu told UN General Assembly delegates they ‘appease evil’
+open image in gallery
+Benjamin Netanyahu told UN General Assembly delegates they ‘appease evil’ (Reuters)
+“Astoundingly, as we fight the terrorists who murdered many of your citizens, you are fighting us. You condemn us, you embargo us, and you wage political and legal warfare – it’s called lawfare – against us.
+
+“I say to the representatives of those nations, this is not an indictment of Israel; it’s an indictment of you. It’s an indictment of weak leaders who appease evil rather than support a nation whose brave soldiers guard you from the barbarians at the gate.”
+
+Netanyahu said he has surrounded Gaza with speakers so that his speech could reach the hostages being held by Hamas. “We will not rest until we bring all of you home,” he told them directly.
+
+To Hamas, he said: “Free the hostages now. If you do, you will live. If you don’t, Israel will hunt you down.”
+
+Delegates walking out in protest as Netanyahu takes to the podium
+open image in gallery
+Delegates walking out in protest as Netanyahu takes to the podium (Getty)
+Israel’s conduct in the war in Gaza has brought a wave of support for a Palestinian state from Western nations. The UK, Canada, Australia and Portugal formally recognised Palestinian statehood on Sunday, followed by France the next day.
+
+
+It has provoked the ire of Israeli ministers in Netanyahu’s coalition government who have pressured him to annex the occupied West Bank in retaliation.
+
+US president Donald Trump, however, said he would not allow that to happen.
+
+“I will not allow Israel to annex the West Bank. Nope, I will not allow it. It’s not going to happen,” he told reporters in the Oval Office on Thursday.
+
+“There’s been enough. It’s time to stop now.”
+
+Netanyahu told a mostly empty chamber ‘we will not allow you to shove a terror state down our throats’
+open image in gallery
+Netanyahu told a mostly empty chamber ‘we will not allow you to shove a terror state down our throats’ (Getty)
+The US, a staunch supporter of Israel, has opposed recognising a Palestinian state, arguing that such a move would reward the militant group Hamas, which seized control of Gaza in 2007.
+
+Trump suggested “a deal on Gaza, and maybe even peace” was imminent – a promise he has repeated numerous times in recent months – after he presented his 21-point plan for ending the war to leaders of several Muslim-majority countries on the sidelines of the UN General Assembly.
+
+According to reports, the US plan consists of ideas that have been discussed in recent months, including proposals put forward by Trump’s son in law Jared Kushner and former prime minister Tony Blair.
+
+Blair has reportedly been in discussions with the US about running a transitional authority in Gaza in the event of a ceasefire.
+
+Smoke billows over Gaza City following an Israeli airstrike on Wednesday
+open image in gallery
+Smoke billows over Gaza City following an Israeli airstrike on Wednesday (AP)
+Blair could head a body called the Gaza International Transitional Authority (Gita), which would seek a UN mandate to govern Gaza as its “supreme political and legal authority” for five years.
+
+Since the outbreak of the war, Blair has made repeated visits to Jerusalem and his think tank, the Tony Blair Institute for Global Change, has drafted a post-war Gaza plan.
+
+Reports suggest the Palestinian Authority, which partly governs the West Bank alongside occupying Israel and has grown increasingly unpopular among Palestinians, would not be part of those plans.
+
+But Mahmoud Abbas, the president of the Palestinian Authority, said his organisation is willing to take responsibility for Gaza during a remote address to the UN General Assembly on Thursday.
+
+Abbas, who was refused a visa to travel to New York, said Hamas would have no part in governing Gaza after the war, and that no matter how much anguish the Palestinians have suffered, they would remain and rebuild their land.
+
+“It will not break our will to survive,” he said. “Palestine is ours.”
+"""

--- a/memoir_ai/classification/iterative_classifier.py
+++ b/memoir_ai/classification/iterative_classifier.py
@@ -10,7 +10,7 @@ import logging
 import time
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 from sqlalchemy.orm import Session
 
@@ -237,7 +237,12 @@ class IterativeClassificationWorkflow:
 
                 # Classify at this level
                 category_name = await self._classify_at_level(
-                    chunk, level, existing_categories, contextual_helper, can_create_new
+                    chunk,
+                    level,
+                    existing_categories,
+                    contextual_helper,
+                    can_create_new,
+                    parent_categories=category_path,
                 )
 
                 metadata = getattr(self, "_last_level_metadata", {})
@@ -317,6 +322,7 @@ class IterativeClassificationWorkflow:
         existing_categories: List[Category],
         contextual_helper: str,
         can_create_new: bool,
+        parent_categories: Optional[Sequence[Category]] = None,
     ) -> str:
         """
         Classify chunk at a specific hierarchy level.
@@ -342,6 +348,7 @@ class IterativeClassificationWorkflow:
                 category_limit=limit,
                 agent=self.single_classifier,
                 chunk_identifier=getattr(chunk, "chunk_id", None),
+                parent_categories=parent_categories,
             )
 
             category_name = selection.category.strip()
@@ -386,6 +393,7 @@ class IterativeClassificationWorkflow:
         existing_categories: List[Category],
         contextual_helper: str,
         can_create_new: bool,
+        parent_categories: Optional[Sequence[Category]] = None,
     ) -> str:
         """Create classification prompt for a specific level."""
 
@@ -396,6 +404,7 @@ class IterativeClassificationWorkflow:
             contextual_helper=contextual_helper,
             can_create_new=can_create_new,
             category_limit=self.category_manager.get_category_limit(level),
+            parent_categories=parent_categories,
         )
 
     async def _get_or_create_category(

--- a/memoir_ai/classification/iterative_classifier.py
+++ b/memoir_ai/classification/iterative_classifier.py
@@ -346,6 +346,11 @@ class IterativeClassificationWorkflow:
 
             category_name = selection.category.strip()
 
+            logger.info(
+                f"LLM selected category '{category_name}' at level {level} "
+                f"(relevance: {selection.ranked_relevance}, {metadata['latency_ms']}ms)"
+            )
+
             if not can_create_new:
                 existing_names = [cat.name for cat in existing_categories]
                 if category_name not in existing_names:

--- a/memoir_ai/core.py
+++ b/memoir_ai/core.py
@@ -440,10 +440,21 @@ class MemoirAI:
 
                     # Store contextual helper if provided
                     if contextual_helper:
+                        helper_tokens = self.text_chunker.count_tokens(
+                            contextual_helper
+                        )
+                        if helper_tokens <= 0:
+                            raise ValidationError(
+                                "Contextual helper must contain at least one token",
+                                field="contextual_helper",
+                                value=contextual_helper,
+                            )
+
                         helper_record = ContextualHelper(
                             source_id=source_id,
-                            helper_text=contextual_helper,
-                            created_at=datetime.now(),
+                            helper_text=contextual_helper.strip(),
+                            token_count=helper_tokens,
+                            is_user_provided=True,
                         )
                         session.add(helper_record)
 

--- a/memoir_ai/core.py
+++ b/memoir_ai/core.py
@@ -517,13 +517,13 @@ class MemoirAI:
     async def query(
         self,
         query_text: str,
+        contextual_helper: str,
         strategy: QueryStrategy = QueryStrategy.ONE_SHOT,
         strategy_params: Optional[Dict[str, Any]] = None,
         prompt_limiting_strategy: Optional[PromptLimitingStrategy] = None,
         max_token_budget: Optional[int] = None,
         use_rankings: Optional[bool] = None,
         limit: int = 10,
-        contextual_helper: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Query stored content using natural language with configurable strategies.

--- a/memoir_ai/core.py
+++ b/memoir_ai/core.py
@@ -431,6 +431,7 @@ class MemoirAI:
                                         cat.name for cat in result.category_path
                                     ),
                                     "category_id": leaf_category.id,
+                                    "classification_latency_ms": result.total_latency_ms,
                                 }
                             )
                         else:

--- a/memoir_ai/llm/__init__.py
+++ b/memoir_ai/llm/__init__.py
@@ -20,6 +20,12 @@ from .agents import (  # Agent factory; Convenience functions; Validation functi
     get_supported_providers,
     validate_model_name,
 )
+from .interactions import (  # Prompt builders and execution helpers
+    build_chunk_classification_prompt,
+    build_query_category_prompt,
+    classify_chunk_with_llm,
+    select_category_for_query,
+)
 from .schemas import (  # Classification schemas; Summarization schemas; Answer schemas; Helper schemas; Metadata and result schemas; Configuration schemas; Utility functions; Schema registries
     ALL_SCHEMAS,
     ANSWER_SCHEMAS,
@@ -81,6 +87,11 @@ __all__ = [
     "create_contextual_helper_agent",
     "create_category_creation_agent",
     "create_category_limit_agent",
+    # Interaction helpers
+    "build_chunk_classification_prompt",
+    "build_query_category_prompt",
+    "classify_chunk_with_llm",
+    "select_category_for_query",
     # Validation
     "validate_model_name",
     "get_supported_providers",

--- a/memoir_ai/llm/interactions.py
+++ b/memoir_ai/llm/interactions.py
@@ -39,7 +39,7 @@ def build_chunk_classification_prompt(
     chunk_content: str,
     level: int,
     existing_categories: Sequence[Any],
-    contextual_helper: Optional[str],
+    contextual_helper: str,
     can_create_new: bool,
     category_limit: Optional[int] = None,
     parent_categories: Optional[Sequence[Any]] = None,
@@ -104,7 +104,7 @@ def build_query_category_prompt(
     query_text: str,
     level: int,
     available_categories: Sequence[Any],
-    contextual_helper: Optional[str],
+    contextual_helper: str,
 ) -> str:
     """Create the prompt used when selecting categories for a user query."""
 
@@ -142,7 +142,7 @@ async def classify_chunk_with_llm(
     chunk_content: str,
     level: int,
     existing_categories: Sequence[Any],
-    contextual_helper: Optional[str],
+    contextual_helper: str,
     can_create_new: bool,
     category_limit: Optional[int] = None,
     agent: Optional[Agent] = None,
@@ -191,9 +191,9 @@ async def classify_chunk_with_llm(
         "level": level,
         "can_create_new": can_create_new,
         "existing_category_names": _extract_category_names(existing_categories),
-        "parent_category_path": _extract_category_names(parent_categories)
-        if parent_categories
-        else None,
+        "parent_category_path": (
+            _extract_category_names(parent_categories) if parent_categories else None
+        ),
     }
 
     return data, metadata
@@ -204,7 +204,7 @@ async def select_category_for_query(
     query_text: str,
     level: int,
     available_categories: Sequence[Any],
-    contextual_helper: Optional[str],
+    contextual_helper: str,
     agent: Optional[Agent] = None,
     model_name: Optional[str] = None,
 ) -> Tuple[QueryCategorySelection, Dict[str, Any]]:

--- a/memoir_ai/llm/interactions.py
+++ b/memoir_ai/llm/interactions.py
@@ -1,0 +1,228 @@
+"""Utility helpers for building prompts and executing LLM interactions."""
+
+from __future__ import annotations
+
+import time
+from datetime import UTC, datetime
+from typing import Any, Dict, Optional, Sequence, Tuple
+
+from pydantic_ai import Agent
+
+from ..exceptions import LLMError
+from .agents import create_classification_agent, create_query_classification_agent
+from .schemas import CategorySelection, QueryCategorySelection
+
+
+def _extract_category_names(categories: Sequence[Any]) -> list[str]:
+    """Normalize a sequence of categories into plain names."""
+
+    names: list[str] = []
+    for category in categories:
+        if isinstance(category, str):
+            if category.strip():
+                names.append(category.strip())
+            continue
+
+        name = getattr(category, "name", None)
+        if isinstance(name, str) and name.strip():
+            names.append(name.strip())
+
+    return names
+
+
+def build_chunk_classification_prompt(
+    *,
+    chunk_content: str,
+    level: int,
+    existing_categories: Sequence[Any],
+    contextual_helper: Optional[str],
+    can_create_new: bool,
+    category_limit: Optional[int] = None,
+) -> str:
+    """Construct the prompt used for single chunk classification."""
+
+    context_parts: list[str] = []
+
+    if contextual_helper:
+        context_parts.append(f"Document Context: {contextual_helper}")
+
+    context_parts.append(f"Classification Level: {level}")
+
+    category_names = _extract_category_names(existing_categories)
+    if category_names:
+        categories_text = ", ".join(category_names)
+        context_parts.append(f"Existing Categories: {categories_text}")
+        if can_create_new:
+            context_parts.append(
+                "Please select from existing categories when possible to avoid duplicates, "
+                "or create a new category if none fit well."
+            )
+        else:
+            if category_limit is not None:
+                context_parts.append(
+                    f"Category limit ({category_limit}) reached. You MUST select from existing categories only."
+                )
+            else:
+                context_parts.append("You MUST select from existing categories only.")
+    else:
+        context_parts.append(
+            "No existing categories at this level. You may create a new category."
+        )
+
+    context_section = "\n".join(context_parts)
+
+    prompt = f"""{context_section}
+
+Please classify the following text into the most appropriate category for level {level}:
+
+Text: {chunk_content}
+
+Provide only the category name."""
+
+    return prompt
+
+
+def build_query_category_prompt(
+    *,
+    query_text: str,
+    level: int,
+    available_categories: Sequence[Any],
+    contextual_helper: Optional[str],
+) -> str:
+    """Create the prompt used when selecting categories for a user query."""
+
+    context_parts: list[str] = [f"Classification Level: {level}"]
+
+    if contextual_helper:
+        context_parts.append(f"Additional Context: {contextual_helper}")
+
+    category_names = _extract_category_names(available_categories)
+    if category_names:
+        context_parts.append("Available Categories: " + ", ".join(category_names))
+    else:
+        context_parts.append(
+            "No explicit categories provided. You must still return a best guess."
+        )
+
+    context_parts.append(
+        "Select the single most relevant category for the user query and provide a "
+        "ranked relevance score from 1 (least relevant) to 10 (most relevant)."
+    )
+
+    context_section = "\n".join(context_parts)
+
+    prompt = f"""{context_section}
+
+User Query: {query_text}
+
+Return the category name and relevance score only."""
+
+    return prompt
+
+
+async def classify_chunk_with_llm(
+    *,
+    chunk_content: str,
+    level: int,
+    existing_categories: Sequence[Any],
+    contextual_helper: Optional[str],
+    can_create_new: bool,
+    category_limit: Optional[int] = None,
+    agent: Optional[Agent] = None,
+    model_name: Optional[str] = None,
+    chunk_identifier: Optional[str] = None,
+) -> Tuple[CategorySelection, Dict[str, Any]]:
+    """Execute a single chunk classification call using Pydantic AI."""
+
+    prompt = build_chunk_classification_prompt(
+        chunk_content=chunk_content,
+        level=level,
+        existing_categories=existing_categories,
+        contextual_helper=contextual_helper,
+        can_create_new=can_create_new,
+        category_limit=category_limit,
+    )
+
+    classification_agent = agent or create_classification_agent(model_name)
+
+    start_time = time.perf_counter()
+    try:
+        response = await classification_agent.run_async(prompt)
+    except Exception as exc:  # pragma: no cover - network/runtime specific
+        raise LLMError(f"Failed to classify chunk at level {level}: {exc}") from exc
+
+    latency_ms = int((time.perf_counter() - start_time) * 1000)
+    data = getattr(response, "data", None)
+    if not isinstance(data, CategorySelection) or not data.category.strip():
+        raise LLMError(f"Empty category response at level {level}")
+
+    metadata = {
+        "prompt": prompt,
+        "latency_ms": latency_ms,
+        "timestamp": datetime.now(UTC),
+        "model_name": model_name or getattr(classification_agent, "model", None),
+        "chunk_identifier": chunk_identifier,
+        "level": level,
+        "can_create_new": can_create_new,
+        "existing_category_names": _extract_category_names(existing_categories),
+    }
+
+    return data, metadata
+
+
+async def select_category_for_query(
+    *,
+    query_text: str,
+    level: int,
+    available_categories: Sequence[Any],
+    contextual_helper: Optional[str],
+    agent: Optional[Agent] = None,
+    model_name: Optional[str] = None,
+) -> Tuple[QueryCategorySelection, Dict[str, Any]]:
+    """Ask an LLM to select the best category for a natural language query."""
+
+    prompt = build_query_category_prompt(
+        query_text=query_text,
+        level=level,
+        available_categories=available_categories,
+        contextual_helper=contextual_helper,
+    )
+
+    query_agent = agent or create_query_classification_agent(model_name)
+
+    start_time = time.perf_counter()
+    try:
+        response = await query_agent.run_async(prompt)
+    except Exception as exc:  # pragma: no cover - network/runtime specific
+        raise LLMError(
+            f"Failed to select category for query at level {level}: {exc}"
+        ) from exc
+
+    latency_ms = int((time.perf_counter() - start_time) * 1000)
+    data = getattr(response, "data", None)
+
+    if isinstance(data, QueryCategorySelection):
+        if not data.category.strip():
+            raise LLMError(f"Empty category response at level {level}")
+        selection = data
+    elif isinstance(data, CategorySelection):
+        if not data.category.strip():
+            raise LLMError(f"Empty category response at level {level}")
+        selection = QueryCategorySelection(
+            category=data.category, ranked_relevance=data.ranked_relevance
+        )
+    else:
+        raise LLMError(
+            "Query classification agent returned an unexpected response type."
+        )
+
+    metadata = {
+        "prompt": prompt,
+        "latency_ms": latency_ms,
+        "timestamp": datetime.now(UTC),
+        "model_name": model_name or getattr(query_agent, "model", None),
+        "level": level,
+        "available_category_names": _extract_category_names(available_categories),
+    }
+
+    return selection, metadata

--- a/memoir_ai/llm/schemas.py
+++ b/memoir_ai/llm/schemas.py
@@ -30,7 +30,9 @@ class BatchClassificationResponse(BaseModel):
 class CategorySelection(BaseModel):
     """Schema for single category selection with relevance ranking."""
 
-    category: str = Field(description="Name of the selected or new category")
+    category: str = Field(
+        description="Name of the selected or new category", min_length=1
+    )
     ranked_relevance: int = Field(
         description="Relevance ranking from 1 to N (N being most relevant)", ge=1
     )
@@ -39,7 +41,7 @@ class CategorySelection(BaseModel):
 class QueryCategorySelection(BaseModel):
     """Schema for query-based category selection during retrieval."""
 
-    category: str = Field(description="Selected category name")
+    category: str = Field(description="Selected category name", min_length=1)
     ranked_relevance: int = Field(description="Relevance ranking from 1 to N", ge=1)
 
 

--- a/memoir_ai/query/query_processor.py
+++ b/memoir_ai/query/query_processor.py
@@ -70,9 +70,9 @@ class QueryProcessor:
     async def process_query(
         self,
         query_text: str,
+        contextual_helper: str,
         strategy: QueryStrategy = QueryStrategy.ONE_SHOT,
         strategy_params: Optional[Dict[str, Any]] = None,
-        contextual_helper: Optional[str] = None,
         chunk_limit_per_path: Optional[int] = None,
         offset: int = 0,
     ) -> QueryResult:

--- a/memoir_ai/query/query_strategy_engine.py
+++ b/memoir_ai/query/query_strategy_engine.py
@@ -159,7 +159,9 @@ class QueryStrategyEngine:
         parent: Optional[Category] = None
 
         for level in range(1, self.hierarchy_depth + 1):
-            categories = self.category_manager.get_existing_categories(level, parent)
+            categories = self.category_manager.get_existing_categories(
+                level, parent.id if parent else None
+            )
             if not categories:
                 break
 
@@ -228,7 +230,7 @@ class QueryStrategyEngine:
             for path in active_paths:
                 parent_category = path[-1] if path else None
                 categories = self.category_manager.get_existing_categories(
-                    level, parent_category
+                    level, parent_category.id if parent_category else None
                 )
                 if not categories:
                     continue

--- a/memoir_ai/query/query_strategy_engine.py
+++ b/memoir_ai/query/query_strategy_engine.py
@@ -111,8 +111,8 @@ class QueryStrategyEngine:
         self,
         query_text: str,
         strategy: QueryStrategy,
+        contextual_helper: str,
         strategy_params: Optional[Dict[str, Any]] = None,
-        contextual_helper: Optional[str] = None,
     ) -> QueryExecutionResult:
         """Execute the requested traversal strategy."""
 
@@ -150,7 +150,7 @@ class QueryStrategyEngine:
         )
 
     async def _execute_one_shot(
-        self, query_text: str, contextual_helper: Optional[str]
+        self, query_text: str, contextual_helper: str
     ) -> Tuple[List[CategoryPath], List[LLMCallResponse]]:
         """Traverse the hierarchy selecting a single path."""
 
@@ -203,7 +203,7 @@ class QueryStrategyEngine:
         query_text: str,
         strategy: QueryStrategy,
         params: Dict[str, Any],
-        contextual_helper: Optional[str],
+        contextual_helper: str,
     ) -> Tuple[List[CategoryPath], List[LLMCallResponse]]:
         """Execute a branching strategy using simple deterministic expansion."""
 
@@ -276,7 +276,7 @@ class QueryStrategyEngine:
     async def _call_selection_agent(
         self,
         query_text: str,
-        contextual_helper: Optional[str],
+        contextual_helper: str,
         level: int,
         available_categories: Sequence[Category],
     ) -> Dict[str, Any]:

--- a/memoir_ai/text_processing/contextual_helper.py
+++ b/memoir_ai/text_processing/contextual_helper.py
@@ -39,7 +39,7 @@ class ContextualHelperGenerator:
 
     def __init__(
         self,
-        auto_source_identification: bool = True,
+        auto_source_identification: bool = False,
         max_tokens: int = 300,
         derivation_budget_tokens: int = 2000,
         max_chunks_for_derivation: int = 5,
@@ -430,8 +430,12 @@ class ContextualHelperGenerator:
                 helper_text += "."
             return helper_text
 
-        # Fallback if no information available
-        return "Document content for classification and retrieval."
+        # If no data available, raise error
+        raise ValidationError(
+            "Insufficient information to generate contextual helper",
+            field="helper_data",
+            value=helper_data,
+        )
 
     def _validate_and_format_helper(
         self, helper_text: str, is_user_provided: bool = False
@@ -561,7 +565,13 @@ class ContextualHelperGenerator:
         return False
 
     def create_user_provided_helper(
-        self, author: str, date: str, topic: str, description: str
+        self,
+        title: str,
+        author: str,
+        date: str,
+        topic: str,
+        source_type: str,
+        description: str,
     ) -> str:
         """
         Create contextual helper from user-provided information.
@@ -576,14 +586,16 @@ class ContextualHelperGenerator:
             Formatted contextual helper text
         """
         # Validate inputs
-        if not all([author, date, topic, description]):
+        if not all([title, author, date, topic, source_type, description]):
             raise ValidationError(
-                "All fields (author, date, topic, description) are required",
+                "All fields (title, author, date, topic, source_type, description) are required",
                 field="user_input",
                 value={
+                    "title": title,
                     "author": author,
                     "date": date,
                     "topic": topic,
+                    "source_type": source_type,
                     "description": description,
                 },
             )

--- a/memoir_ai/text_processing/contextual_helper.py
+++ b/memoir_ai/text_processing/contextual_helper.py
@@ -39,7 +39,7 @@ class ContextualHelperGenerator:
 
     def __init__(
         self,
-        auto_source_identification: bool = False,
+        auto_source_identification: bool = True,
         max_tokens: int = 300,
         derivation_budget_tokens: int = 2000,
         max_chunks_for_derivation: int = 5,

--- a/related_projects.md
+++ b/related_projects.md
@@ -1,0 +1,130 @@
+Got it — here’s the full text version you can copy-paste directly. I’ve added GitHub / arXiv / doc URLs for each project and paper where available.
+
+---
+
+# Alternatives to Vector Database RAG Systems
+
+This document summarizes research papers, GitHub repos, and open-source libraries related to **RAG systems without vector databases** and **LLM memory architectures**, including commentary on how they relate to the hierarchical SQL-only retrieval idea.
+
+---
+
+## 📄 Research Papers & Academic Work
+
+### Hybrid / Hierarchical / Non-Vector Retrieval
+
+- **NeuSym-RAG: Hybrid Neural Symbolic Retrieval (2025)**
+  Combines SQL filtering with vector retrieval. SQL is used as a pre-filter step.
+  _Comment:_ Not pure SQL, but shows promise for hybrid architectures.
+  [ACL Anthology PDF](https://aclanthology.org/2025.acl-long.311.pdf)
+
+- **HIRO: Hierarchical Information Retrieval Optimization (2024)**
+  Organizes documents in levels of summarization, traversed like a tree to prune irrelevant branches.
+  _Comment:_ Hierarchical design overlaps with the “categorical narrowing” idea.
+  [arXiv](https://arxiv.org/abs/2406.09979)
+
+- **CRUSH4SQL: Collective Retrieval Using Schema Hallucination for Text2SQL (2023)**
+  Lets LLMs hallucinate minimal schemas, then retrieves SQL subsets.
+  _Comment:_ Works in structured domains (schema retrieval) rather than documents.
+  [arXiv](https://arxiv.org/abs/2311.01173)
+
+- **RB-SQL: A Retrieval-based LLM Framework for Text-to-SQL (2024)**
+  Retrieves concise table/column subsets as context.
+  _Comment:_ More SQL schema-focused, but retrieval principles overlap.
+  [arXiv](https://arxiv.org/abs/2407.08273)
+
+- **Structured Hierarchical Retrieval (LlamaIndex)**
+  Supports “tree indices” and structured retrieval.
+  _Comment:_ Hierarchical indexing, but usually backed by embeddings at the leaves.
+  [Docs](https://docs.llamaindex.ai/en/v0.9.48/examples/query_engine/multi_doc_auto_retrieval/multi_doc_auto_retrieval.html)
+
+- **DuckDB + RAG Integration (FlockMTL, 2025)**
+  Treats `MODEL` and `PROMPT` as schema objects inside DuckDB.
+  _Comment:_ Embeds LLM operations inside SQL, bridging structured + unstructured retrieval.
+  [arXiv](https://arxiv.org/abs/2504.01157)
+
+---
+
+## 🧠 LLM Memory Libraries
+
+1. **Memori (GibsonAI/memori)**
+   SQL-native memory engine using Postgres/MySQL. Entity extraction + SQL retrieval.
+   _Comment:_ Very close to “SQL instead of vector DB,” though geared to conversational memory.
+   [GitHub](https://github.com/GibsonAI/memori)
+
+2. **MemoryOS (BAI-LAB/MemoryOS)**
+   Hierarchical “memory operating system” with storage/retrieval layers.
+   _Comment:_ Hierarchical structure overlaps conceptually, unclear if embeddings are used.
+   [GitHub](https://github.com/BAI-LAB/MemoryOS)
+
+3. **GMemory (bingreeky/GMemory)**
+   Tracing hierarchical memory for multi-agent systems.
+   _Comment:_ Hierarchy is key, but not document-RAG oriented.
+   [GitHub](https://github.com/bingreeky/GMemory)
+
+4. **Memoripy (caspianmoon/memoripy)**
+   Short/long-term memory, clustering, graph associations.
+   _Comment:_ Uses embeddings internally, not pure SQL.
+   [GitHub](https://github.com/caspianmoon/memoripy)
+
+5. **HighNoonLLM**
+   Hierarchical spatial neural memory, splitting sequences into memory trees.
+   _Comment:_ More neural architecture, but similar “tree narrowing” principles.
+   [GitHub](https://github.com/versoindustries/HighNoonLLM)
+
+6. **Beyond Quacking (DuckDB + RAG Integration, FlockMTL)**
+   Integrates LLM operations (`MODEL`, `PROMPT`) into DuckDB schema.
+   _Comment:_ Not purely memory but important as it embeds retrieval and model ops directly in SQL.
+   [arXiv](https://arxiv.org/abs/2504.01157)
+
+7. **HMT (Hierarchical Memory Transformer)**
+   Transformer model with memory structured hierarchically (segment-level recurrence).
+   _Comment:_ A neural approach to hierarchical memory, aligns with narrowing search spaces.
+   [arXiv](https://arxiv.org/abs/2309.10276)
+
+---
+
+## 📚 RAG Without Vector Databases
+
+1. **harshitv804/RAG-without-Vector-DB**
+   RAG system using **TF-IDF retriever**, long context, and reranking instead of embeddings.
+   _Comment:_ Closest open-source attempt at “RAG without vectors.”
+   [GitHub](https://github.com/harshitv804/RAG-without-Vector-DB)
+
+2. **xetdata/RagIRBench**
+   Benchmark repo showing classical IR (BM25/TF-IDF) can replace vector DBs for many cases.
+   _Comment:_ Not a production library, but a strong proof-of-concept.
+   [GitHub](https://github.com/xetdata/RagIRBench)
+
+3. **PolyRAG (QuentinFuxa/PolyRAG)**
+   Combines SQL, RAG, and PDF parsing for multi-source Q&A.
+   _Comment:_ Hybrid approach, doesn’t eliminate vectors entirely.
+   [GitHub](https://github.com/QuentinFuxa/PolyRAG)
+
+4. **Azure-Samples/azure-sql-db-chatbot**
+   SQL database + OpenAI chatbot demo. Embeddings computed inside SQL with vector functions.
+   _Comment:_ SQL-based vector retrieval, not pure symbolic.
+   [GitHub](https://github.com/Azure-Samples/azure-sql-db-chatbot)
+
+5. **vanna-ai/vanna**
+   Python library that turns natural language into SQL queries.
+   _Comment:_ Retrieval is structured (SQL) not document-based; no vector DB needed.
+   [GitHub](https://github.com/vanna-ai/vanna)
+
+6. **RAG-with-SQLite-FTS (various forks)**
+   Several experimental repos use **SQLite FTS5** (full-text search) instead of vector DBs for retrieval.
+   _Comment:_ Good minimal examples, but usually demos not scalable systems.
+   Example: [GitHub](https://github.com/kevinamiri/RAG-SQLite-FTS)
+
+7. **DuckDB FTS-based RAG demos**
+   Some repos show **DuckDB full-text search** powering RAG pipelines, often with BM25 scoring.
+   _Comment:_ Promising since DuckDB can handle larger corpora efficiently with SQL-like queries.
+   Example: [GitHub](https://github.com/tobilg/duckdb-fts-demo)
+
+---
+
+## ⚖️ Observations Across Approaches
+
+- **SQL-only retrieval** is rare. Most projects either (a) use embeddings inside the SQL engine, or (b) use classical IR as a pre-filter.
+- **Hierarchical designs** (HIRO, HighNoon, LlamaIndex tree, HMT) show strong interest in tree-based narrowing, but not yet as a SQL-native pipeline.
+- **Your approach (hierarchical categorical narrowing + SQL storage)** seems novel: no embeddings, fixed branching factor, and simple categorical outputs from the LLM.
+- **Closest practical repos:** `Memori` (SQL-native memory) and `RAG-without-Vector-DB` (classical IR retriever). These can serve as baseline comparisons.

--- a/tests/test_llm_agents.py
+++ b/tests/test_llm_agents.py
@@ -204,9 +204,11 @@ class TestAgentFactory:
         # Check that the configuration was passed correctly
         call_args = mock_agent_class.call_args
         assert call_args[1]["model"] == "grok:grok-1"
-        assert call_args[1]["temperature"] == 0.7
-        assert call_args[1]["max_tokens"] == 2000
-        assert call_args[1]["timeout"] == 45
+        model_settings = call_args[1]["model_settings"]
+        assert model_settings is not None
+        assert model_settings["temperature"] == 0.7
+        assert model_settings["max_tokens"] == 2000
+        assert model_settings["timeout"] == 45.0
         assert call_args[1]["retries"] == 2
 
     @patch("memoir_ai.llm.agents.Agent")

--- a/tests/test_llm_interactions.py
+++ b/tests/test_llm_interactions.py
@@ -1,0 +1,159 @@
+"""Tests for LLM interaction helpers."""
+
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from memoir_ai.exceptions import LLMError
+from memoir_ai.llm.interactions import (
+    build_chunk_classification_prompt,
+    build_query_category_prompt,
+    classify_chunk_with_llm,
+    select_category_for_query,
+)
+from memoir_ai.llm.schemas import CategorySelection, QueryCategorySelection
+
+
+class DummyCategory:
+    """Simple helper class providing a name attribute."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+def test_build_chunk_classification_prompt_with_categories() -> None:
+    """Ensure prompts include expected context when categories exist."""
+
+    prompt = build_chunk_classification_prompt(
+        chunk_content="AI research advances",
+        level=2,
+        existing_categories=[DummyCategory("Technology"), DummyCategory("Science")],
+        contextual_helper="Academic paper",
+        can_create_new=True,
+        category_limit=10,
+    )
+
+    assert "Document Context: Academic paper" in prompt
+    assert "Classification Level: 2" in prompt
+    assert "Existing Categories: Technology, Science" in prompt
+    assert "AI research advances" in prompt
+
+
+def test_build_chunk_classification_prompt_without_categories() -> None:
+    """When no categories are provided the prompt should allow creation."""
+
+    prompt = build_chunk_classification_prompt(
+        chunk_content="General news",
+        level=1,
+        existing_categories=[],
+        contextual_helper=None,
+        can_create_new=True,
+    )
+
+    assert "No existing categories at this level" in prompt
+    assert "General news" in prompt
+
+
+def test_build_query_category_prompt() -> None:
+    """Query prompt should list options and instructions."""
+
+    prompt = build_query_category_prompt(
+        query_text="Explain the latest in quantum computing",
+        level=1,
+        available_categories=["Technology", "Science"],
+        contextual_helper="Looking for research topics",
+    )
+
+    assert "Available Categories: Technology, Science" in prompt
+    assert "User Query: Explain the latest in quantum computing" in prompt
+    assert "ranked relevance score" in prompt
+
+
+@pytest.mark.asyncio
+async def test_classify_chunk_with_llm_success() -> None:
+    """Successful classification should return the model output and metadata."""
+
+    agent = Mock()
+    agent.run_async = AsyncMock(
+        return_value=SimpleNamespace(
+            data=CategorySelection(category="Technology", ranked_relevance=5)
+        )
+    )
+
+    selection, metadata = await classify_chunk_with_llm(
+        chunk_content="AI breakthroughs",
+        level=1,
+        existing_categories=["Technology"],
+        contextual_helper="Tech blog",
+        can_create_new=False,
+        category_limit=5,
+        agent=agent,
+        chunk_identifier="chunk-1",
+    )
+
+    agent.run_async.assert_awaited()
+    assert selection.category == "Technology"
+    assert metadata["chunk_identifier"] == "chunk-1"
+    assert "latency_ms" in metadata
+
+
+@pytest.mark.asyncio
+async def test_classify_chunk_with_llm_invalid_response() -> None:
+    """Non CategorySelection responses should raise an error."""
+
+    agent = Mock()
+    agent.run_async = AsyncMock(return_value=SimpleNamespace(data=None))
+
+    with pytest.raises(LLMError):
+        await classify_chunk_with_llm(
+            chunk_content="AI breakthroughs",
+            level=1,
+            existing_categories=["Technology"],
+            contextual_helper="Tech blog",
+            can_create_new=False,
+            agent=agent,
+        )
+
+
+@pytest.mark.asyncio
+async def test_select_category_for_query_success() -> None:
+    """Successful query selection should return schema output."""
+
+    agent = Mock()
+    agent.run_async = AsyncMock(
+        return_value=SimpleNamespace(
+            data=QueryCategorySelection(category="AI", ranked_relevance=7)
+        )
+    )
+
+    selection, metadata = await select_category_for_query(
+        query_text="deep learning",
+        level=2,
+        available_categories=[DummyCategory("AI"), DummyCategory("ML")],
+        contextual_helper="Research",
+        agent=agent,
+    )
+
+    agent.run_async.assert_awaited()
+    assert selection.category == "AI"
+    assert metadata["available_category_names"] == ["AI", "ML"]
+    assert metadata["level"] == 2
+
+
+@pytest.mark.asyncio
+async def test_select_category_for_query_invalid_response() -> None:
+    """Unexpected responses should trigger an LLMError."""
+
+    agent = Mock()
+    agent.run_async = AsyncMock(return_value=SimpleNamespace(data="invalid"))
+
+    with pytest.raises(LLMError):
+        await select_category_for_query(
+            query_text="deep learning",
+            level=2,
+            available_categories=["AI"],
+            contextual_helper=None,
+            agent=agent,
+        )

--- a/tests/test_llm_interactions.py
+++ b/tests/test_llm_interactions.py
@@ -33,10 +33,13 @@ def test_build_chunk_classification_prompt_with_categories() -> None:
         contextual_helper="Academic paper",
         can_create_new=True,
         category_limit=10,
+        parent_categories=[DummyCategory("Research")],
     )
 
     assert "Document Context: Academic paper" in prompt
     assert "Classification Level: 2" in prompt
+    assert "Parent Category Path: Research" in prompt
+    assert "more specific" in prompt
     assert "Existing Categories: Technology, Science" in prompt
     assert "AI research advances" in prompt
 
@@ -91,12 +94,14 @@ async def test_classify_chunk_with_llm_success() -> None:
         category_limit=5,
         agent=agent,
         chunk_identifier="chunk-1",
+        parent_categories=[DummyCategory("Computing")],
     )
 
     agent.run_async.assert_awaited()
     assert selection.category == "Technology"
     assert metadata["chunk_identifier"] == "chunk-1"
     assert "latency_ms" in metadata
+    assert metadata["parent_category_path"] == ["Computing"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_query_processor.py
+++ b/tests/test_query_processor.py
@@ -142,6 +142,7 @@ class TestQueryProcessor:
             result = await self.processor.process_query(
                 query_text="machine learning algorithms",
                 strategy=QueryStrategy.ONE_SHOT,
+                contextual_helper="test context",
             )
 
             # Verify calls
@@ -149,7 +150,7 @@ class TestQueryProcessor:
                 query_text="machine learning algorithms",
                 strategy=QueryStrategy.ONE_SHOT,
                 strategy_params={},
-                contextual_helper=None,
+                contextual_helper="test context",
             )
 
             mock_retriever.assert_called_once_with(
@@ -233,7 +234,9 @@ class TestQueryProcessor:
             mock_strategy.side_effect = Exception("Strategy execution failed")
 
             result = await self.processor.process_query(
-                query_text="test query", strategy=QueryStrategy.ONE_SHOT
+                query_text="test query",
+                strategy=QueryStrategy.ONE_SHOT,
+                contextual_helper="test context",
             )
 
             # Verify error result

--- a/tests/test_query_strategy_engine.py
+++ b/tests/test_query_strategy_engine.py
@@ -141,7 +141,9 @@ class TestQueryStrategyEngine:
 
             with pytest.raises(ValidationError) as exc_info:
                 await engine.execute_strategy(
-                    query_text="test query", strategy="invalid_strategy"
+                    query_text="test query",
+                    strategy="invalid_strategy",
+                    contextual_helper="",
                 )
             assert "Unknown strategy" in str(exc_info.value)
 
@@ -199,6 +201,7 @@ class TestQueryStrategyEngine:
             result = await engine.execute_strategy(
                 query_text="machine learning algorithms",
                 strategy=QueryStrategy.ONE_SHOT,
+                contextual_helper="test context",
             )
 
             assert isinstance(result, QueryExecutionResult)

--- a/tests/test_query_strategy_engine.py
+++ b/tests/test_query_strategy_engine.py
@@ -213,6 +213,11 @@ class TestQueryStrategyEngine:
             assert path.path[1].name == "AI"
             assert path.path[2].name == "ML"
 
+            calls = self.mock_category_manager.get_existing_categories.call_args_list
+            assert calls[0].args == (1, None)
+            assert calls[1].args == (2, 1)
+            assert calls[2].args == (3, 3)
+
     def test_deduplicate_paths(self) -> None:
         """Test path deduplication."""
         with patch(


### PR DESCRIPTION
## Summary
- add shared prompt builders plus async helpers that execute LLM-powered chunk and query classification
- integrate the helpers into the iterative classifier and query strategy engine while capturing latency metadata
- add comprehensive interaction tests and a runnable end-to-end example that exercises real LLM calls through Pydantic AI

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d64f500b088320a73a5523ffb9695b