### PR TITLE
Ensure L1 categories build on document context

### DIFF
--- a/memoir_ai/llm/interactions.py
+++ b/memoir_ai/llm/interactions.py
@@ -49,7 +49,15 @@ def build_chunk_classification_prompt(
     context_parts: list[str] = []
 
     if contextual_helper:
-        context_parts.append(f"Document Context: {contextual_helper}")
+        context_parts.append(f"Document Context (root category): {contextual_helper}")
+        if level == 1:
+            context_parts.append(
+                "Level 1 categories must be direct subcategories of this document context."
+            )
+        else:
+            context_parts.append(
+                "All categories must remain consistent with the document context and parent selections."
+            )
 
     context_parts.append(f"Classification Level: {level}")
 

--- a/tests/test_llm_interactions.py
+++ b/tests/test_llm_interactions.py
@@ -36,7 +36,8 @@ def test_build_chunk_classification_prompt_with_categories() -> None:
         parent_categories=[DummyCategory("Research")],
     )
 
-    assert "Document Context: Academic paper" in prompt
+    assert "Document Context (root category): Academic paper" in prompt
+    assert "remain consistent with the document context" in prompt
     assert "Classification Level: 2" in prompt
     assert "Parent Category Path: Research" in prompt
     assert "more specific" in prompt


### PR DESCRIPTION
## Summary
- treat the document context in classification prompts as the root category
- guide level 1 selections to be direct subcategories and reinforce context alignment for deeper levels
- update prompt unit test expectations for the new guidance

## Testing
- `pytest tests/test_llm_interactions.py`


------
https://chatgpt.com/codex/tasks/task_e_68d92b8ea2bc8320a9105db5308ab709